### PR TITLE
Add new Test Cases for 0.9.3 rebase

### DIFF
--- a/Sanity/cap-audit/main.fmf
+++ b/Sanity/cap-audit/main.fmf
@@ -1,0 +1,24 @@
+summary: Verify cap-audit produces actionable and accurate capability recommendations
+description: |
+    cap-audit is a new tool in libcap-ng 0.9.2+ that uses eBPF to hook
+    capability checks in the kernel, accurately determining what capabilities
+    a program needs. This test verifies basic functionality and accuracy
+    by auditing programs with known capability requirements.
+contact: Adam Prikryl <aprikryl@redhat.com>
+test: ./runtest.sh
+duration: 10m
+enabled: true
+tier: '1'
+tag:
+  - CI-Tier-1
+  - Tier1
+  - Tier1security
+  - TIPpass_Security
+recommend:
+  - libcap-ng
+  - libcap-ng-utils
+  - iputils
+adjust:
+  - enabled: false
+    when: distro < rhel-10
+    continue: false

--- a/Sanity/cap-audit/runtest.sh
+++ b/Sanity/cap-audit/runtest.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/libcap-ng/Sanity/cap-audit
+#   Description: Verify cap-audit produces actionable and accurate
+#                capability recommendations
+#   Author: Adam Prikryl <aprikryl@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2026 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="libcap-ng"
+
+rlJournalStart
+
+    rlPhaseStartSetup
+        rlAssertRpm "$PACKAGE"
+        rlAssertRpm "${PACKAGE}-utils"
+        rlRun "which cap-audit" 0 "cap-audit binary must be in PATH"
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+    rlPhaseEnd
+
+    rlPhaseStartTest "CapAuditBasicRun"
+        rlRun "cap-audit -- ping -c1 127.0.0.1 > ${TmpDir}/ping-audit.out 2>&1" 0 \
+            "cap-audit should successfully audit ping"
+        rlRun "cat ${TmpDir}/ping-audit.out"
+        rlRun "test -s ${TmpDir}/ping-audit.out" 0 "Output must be non-empty"
+    rlPhaseEnd
+
+    rlPhaseStartTest "CapAuditOutputStructure"
+        rlAssertGrep "CAPABILITY ANALYSIS FOR" "${TmpDir}/ping-audit.out"
+        rlAssertGrep "REQUIRED CAPABILITIES" "${TmpDir}/ping-audit.out"
+        rlAssertGrep "SUMMARY" "${TmpDir}/ping-audit.out"
+        rlAssertGrep "RECOMMENDATIONS" "${TmpDir}/ping-audit.out"
+        rlAssertGrep "Total capability checks:" "${TmpDir}/ping-audit.out"
+    rlPhaseEnd
+
+    rlPhaseStartTest "CapAuditDetectsCapability"
+        rlRun "cap-audit -- chroot / /bin/true > ${TmpDir}/chroot-audit.out 2>&1" 0 \
+            "cap-audit should successfully audit chroot"
+        rlRun "cat ${TmpDir}/chroot-audit.out"
+        rlAssertGrep "sys_chroot" "${TmpDir}/chroot-audit.out"
+        rlAssertGrep "chroot" "${TmpDir}/chroot-audit.out"
+        rlAssertGrep "REQUIRED CAPABILITIES" "${TmpDir}/chroot-audit.out"
+    rlPhaseEnd
+
+    rlPhaseStartTest "CapAuditUnprivilegedTarget"
+        rlRun "cap-audit -- cat /dev/null > ${TmpDir}/cat-audit.out 2>&1" 0 \
+            "cap-audit should successfully audit an unprivileged command"
+        rlRun "cat ${TmpDir}/cat-audit.out"
+        rlAssertGrep "does not require" "${TmpDir}/cat-audit.out"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rm -rf ${TmpDir}" 0 "Removing tmp directory"
+    rlPhaseEnd
+
+rlJournalPrintText
+rlJournalEnd

--- a/Sanity/netcap-advanced/main.fmf
+++ b/Sanity/netcap-advanced/main.fmf
@@ -1,0 +1,24 @@
+summary: Verify netcap --advanced produces accurate situational awareness
+description: |
+    netcap --advanced is a new option in libcap-ng 0.9.2+ that calls out
+    the attack surface for all network facing applications and highlights
+    the defenses taken to reduce desirability for attack. This test verifies
+    basic functionality and output accuracy.
+contact: Adam Prikryl <aprikryl@redhat.com>
+test: ./runtest.sh
+duration: 5m
+enabled: true
+tier: '1'
+tag:
+  - CI-Tier-1
+  - Tier1
+  - Tier1security
+  - TIPpass_Security
+recommend:
+  - libcap-ng
+  - libcap-ng-utils
+  - openssh-server
+adjust:
+  - enabled: false
+    when: distro < rhel-10
+    continue: false

--- a/Sanity/netcap-advanced/runtest.sh
+++ b/Sanity/netcap-advanced/runtest.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/libcap-ng/Sanity/netcap-advanced
+#   Description: Verify netcap --advanced produces accurate
+#                situational awareness for admins
+#   Author: Adam Prikryl <aprikryl@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2026 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="libcap-ng"
+SSHD_STARTED_BY_TEST=false
+ADVANCED_AVAILABLE=false
+
+rlJournalStart
+
+    rlPhaseStartSetup
+        rlAssertRpm "$PACKAGE"
+        rlAssertRpm "${PACKAGE}-utils"
+        rlRun "which netcap" 0 "netcap binary must be in PATH"
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        if ! systemctl is-active sshd &>/dev/null; then
+            rlRun "systemctl start sshd" 0 "Starting sshd for test"
+            SSHD_STARTED_BY_TEST=true
+        fi
+        if netcap --advanced &>/dev/null; then
+            ADVANCED_AVAILABLE=true
+            rlLog "netcap --advanced is available"
+        else
+            rlLog "netcap --advanced is NOT available (disabled at configure time?)"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "NetcapBasicStillWorks"
+        rlRun "netcap > ${TmpDir}/netcap-basic.out 2>&1" 0 \
+            "Basic netcap must still work"
+        rlRun "cat ${TmpDir}/netcap-basic.out"
+        rlRun "test -s ${TmpDir}/netcap-basic.out" 0 "Basic output must be non-empty"
+    rlPhaseEnd
+
+    rlPhaseStartTest "NetcapAdvancedRun"
+        if ! $ADVANCED_AVAILABLE; then
+            rlFail "netcap --advanced was disabled at configure time — required kernel headers were missing from the build"
+        else
+            rlRun "netcap --advanced > ${TmpDir}/netcap-advanced.out 2>&1" 0 \
+                "netcap --advanced must run successfully"
+            rlRun "cat ${TmpDir}/netcap-advanced.out"
+            rlRun "test -s ${TmpDir}/netcap-advanced.out" 0 "Advanced output must be non-empty"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "NetcapAdvancedExtraOutput"
+        if ! $ADVANCED_AVAILABLE; then
+            rlLog "Skipping — netcap --advanced not available"
+        else
+            BASIC_COLS=$(head -1 "${TmpDir}/netcap-basic.out" | awk '{print NF}')
+            ADVANCED_COLS=$(head -1 "${TmpDir}/netcap-advanced.out" | awk '{print NF}')
+            rlLog "Basic mode columns: ${BASIC_COLS}, Advanced mode columns: ${ADVANCED_COLS}"
+            if [ "$ADVANCED_COLS" -gt "$BASIC_COLS" ]; then
+                rlPass "Advanced mode produces more columns (${ADVANCED_COLS}) than basic (${BASIC_COLS})"
+            else
+                BASIC_SIZE=$(wc -c < "${TmpDir}/netcap-basic.out")
+                ADVANCED_SIZE=$(wc -c < "${TmpDir}/netcap-advanced.out")
+                rlLog "Basic output size: ${BASIC_SIZE} bytes, Advanced: ${ADVANCED_SIZE} bytes"
+                rlRun "[ $ADVANCED_SIZE -ge $BASIC_SIZE ]" 0 \
+                    "Advanced output must be at least as large as basic output"
+            fi
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "NetcapAdvancedSshdVisible"
+        if ! $ADVANCED_AVAILABLE; then
+            rlLog "Skipping — netcap --advanced not available"
+        else
+            rlAssertGrep "sshd" "${TmpDir}/netcap-advanced.out"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        if $SSHD_STARTED_BY_TEST; then
+            rlRun "systemctl stop sshd" 0 "Stopping sshd started by test"
+        fi
+        rlRun "rm -rf ${TmpDir}" 0 "Removing tmp directory"
+    rlPhaseEnd
+
+rlJournalPrintText
+rlJournalEnd

--- a/Sanity/smoke-test/runtest.sh
+++ b/Sanity/smoke-test/runtest.sh
@@ -57,7 +57,7 @@ rlJournalStart
 
         rlRun "/sbin/runuser -s /bin/sh -c 'rpmbuild -vv -bc ${SPECFILE}' -- ${TESTUSER}" 0 "Building libcap-ng source RPM"
 
-        rlRun "/sbin/runuser -s /bin/sh -c 'cd ~/rpmbuild/BUILD/libcap-ng-[0-9]*[0-9]; [ -f Makefile ] || cd libcap-ng-*; make check' > make.check.out -- ${TESTUSER}" 0 "Running libcap-ng self-test (as non-root user)"
+        rlRun "/sbin/runuser -s /bin/sh -c 'set -- ~/rpmbuild/BUILD/libcap-ng-[0-9]*[0-9]; cd \"\$1\"; [ -f Makefile ] || cd libcap-ng-*/; make check' > make.check.out -- ${TESTUSER}" 0 "Running libcap-ng self-test (as non-root user)"
         rlRun "cat make.check.out"
 
         if rlIsRHEL 6; then


### PR DESCRIPTION
## Summary by Sourcery

Add new Beakerlib sanity tests for libcap-ng utilities and improve robustness of the existing smoke test build directory selection.

New Features:
- Add a netcap-advanced sanity test that validates basic and advanced netcap output, ensures extra detail in advanced mode, and checks visibility of sshd.
- Add a cap-audit sanity test that verifies cap-audit runs against various commands and produces structured, actionable capability analysis output.

Enhancements:
- Harden the smoke-test self-test invocation by making the build directory resolution for libcap-ng more robust before running make check.

Tests:
- Introduce dedicated Beakerlib runtest.sh scripts and metadata for netcap-advanced and cap-audit sanity test scenarios in the libcap-ng test suite.