### PR TITLE
Add missing descriptions to main.fmf test cases

### DIFF
--- a/Regression/bz593635-Capabilities-can-t-be-set-on-just-a-thread/main.fmf
+++ b/Regression/bz593635-Capabilities-can-t-be-set-on-just-a-thread/main.fmf
@@ -1,6 +1,9 @@
 summary: When changing capabilities on a thread, it actually changes the 
     capabilities
-description: ''
+description: |
+    Verify that capabilities can be independently set on individual threads
+    by compiling and running a multithreaded program that uses libcap-ng to
+    apply different capabilities on separate pthreads.
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/smoke-test/main.fmf
+++ b/Sanity/smoke-test/main.fmf
@@ -1,5 +1,8 @@
 summary: Test calls upstream test suite.
-description: ''
+description: |
+    Verify that the libcap-ng upstream test suite passes by rebuilding the
+    source RPM as a non-root user and running make check, ensuring all
+    tests pass without failures.
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
 recommend:


### PR DESCRIPTION
Add descriptions to test cases that had empty or missing description field in main.fmf.

## Summary by Sourcery

Enhancements:
- Improve test metadata by populating previously empty or missing description fields in regression and smoke test cases.