### PR TITLE
Disable test scenario, feature land in 10.4

### DIFF
--- a/Sanity/netcap-advanced/main.fmf
+++ b/Sanity/netcap-advanced/main.fmf
@@ -20,5 +20,6 @@ recommend:
   - openssh-server
 adjust:
   - enabled: false
-    when: distro < rhel-10
+    when: distro < rhel-10.4
+    because: functionality should land in 10.4
     continue: false


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Disable the netcap-advanced sanity test case in the FMF metadata so it no longer runs in the 10.4 cycle.